### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN go mod download
 COPY cmd/ ./cmd/
 COPY internal/ ./internal/
 # cache-bust: v1.0.1
-RUN cp -r /tmp/frontend/dist/ ./internal/router/static/ && \
+RUN cp -r /tmp/frontend/dist/. ./internal/router/static/ && \
     CGO_ENABLED=0 go build -trimpath \
         -ldflags="-s -w -X 'github.com/mbentancour/babytracker/internal/version.Version=${BUILD_VERSION}'" \
         -o /usr/local/bin/babytracker ./cmd/babytracker/


### PR DESCRIPTION
Hi,

There is a problem with the HA add-on:
When I opened the babytracker I got a blank page with the following text: _.gitkeep_ and _/dist/._

The following change in the file Dockerfile (line 47) fixed it for me:
`RUN cp -r /tmp/frontend/dist/ ./internal/router/static/ && \`
to:
`RUN cp -r /tmp/frontend/dist/. ./internal/router/static/ && \`