### PR TITLE
Make the Growth tab respect the feature toggles

### DIFF
--- a/frontend/src/tabs/GrowthTab.jsx
+++ b/frontend/src/tabs/GrowthTab.jsx
@@ -42,7 +42,7 @@ const feedingCountFills = {
 export default function GrowthTab({ weights, heights, headCircumferences = [], bmiEntries = [], monthlyFeedings, monthlySleep, child, onEditEntry, onDeleteEntry, canWrite = () => true }) {
   const units = useUnits();
   const { t } = useI18n();
-  const { prefs } = usePreferences();
+  const { prefs, isFeatureEnabled } = usePreferences();
   const [dayModal, setDayModal] = useState(null);
   const [selectedBar, setSelectedBar] = useState(null);
   const [whoView, setWhoView] = useState({ weight: false, height: false, headcirc: false, bmi: false });
@@ -152,7 +152,7 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
           marginBottom: 20,
         }}
       >
-        <div className="fade-in fade-in-1">
+        {isFeatureEnabled("weight") && <div className="fade-in fade-in-1">
           <div
             onClick={() => latestWeight && canWrite("weight") && onEditEntry?.("weight", latestWeight)}
             style={{
@@ -197,9 +197,9 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </div>
-        </div>
+        </div>}
 
-        <div className="fade-in fade-in-2">
+        {isFeatureEnabled("height") && <div className="fade-in fade-in-2">
           <div
             onClick={() => latestHeight && canWrite("height") && onEditEntry?.("height", latestHeight)}
             style={{
@@ -244,9 +244,9 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </div>
-        </div>
+        </div>}
 
-        <div className="fade-in fade-in-3">
+        {isFeatureEnabled("headcirc") && <div className="fade-in fade-in-3">
           <div
             onClick={() => latestHeadCirc && canWrite("headcirc") && onEditEntry?.("headcirc", latestHeadCirc)}
             style={{
@@ -278,9 +278,9 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </div>
-        </div>
+        </div>}
 
-        <div className="fade-in fade-in-4">
+        {isFeatureEnabled("bmi") && <div className="fade-in fade-in-4">
           <div
             onClick={() => latestManualBMI && canWrite("bmi") && onEditEntry?.("bmi", latestManualBMI)}
             style={{
@@ -316,7 +316,7 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
                 : t("general.noData")}
             </div>
           </div>
-        </div>
+        </div>}
       </div>
 
       {/* Charts */}
@@ -328,7 +328,7 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
         }}
       >
         {/* Daily Feeding Totals */}
-        <div className="fade-in fade-in-5">
+        {isFeatureEnabled("feeding") && <div className="fade-in fade-in-5">
           <SectionCard title={t("growth.dailyFeeding30d")} icon={<Icons.Bottle />} color={colors.feeding}>
             {feedingSeries.some((d) => d.amount > 0) ? (
               <>
@@ -369,10 +369,10 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
 
         {/* Daily Feeding Counts by Type */}
-        <div className="fade-in fade-in-6">
+        {isFeatureEnabled("feeding") && <div className="fade-in fade-in-6">
           <SectionCard title={t("growth.dailyFeedingCount30d")} icon={<Icons.Bottle />} color={colors.feeding}>
             {feedingCountSeries.some((d) => FEEDING_COUNT_KEYS.some((k) => d[k] > 0)) ? (
               <div style={{ height: 200 }}>
@@ -400,10 +400,10 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
 
         {/* Daily Sleep Totals */}
-        <div className="fade-in fade-in-7">
+        {isFeatureEnabled("sleep") && <div className="fade-in fade-in-7">
           <SectionCard title={t("growth.dailySleep30d")} icon={<Icons.Moon />} color={colors.sleep}>
             {sleepSeries.some((d) => d.hours > 0) ? (
               <>
@@ -444,10 +444,10 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
 
         {/* Weight Chart */}
-        <div className="fade-in fade-in-8">
+        {isFeatureEnabled("weight") && <div className="fade-in fade-in-8">
           <SectionCard
             title={t("growth.weightTrend")}
             icon={<Icons.Weight />}
@@ -497,10 +497,10 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
 
         {/* Height Chart */}
-        <div className="fade-in fade-in-9">
+        {isFeatureEnabled("height") && <div className="fade-in fade-in-9">
           <SectionCard
             title={t("growth.heightTrend")}
             icon={<Icons.Ruler />}
@@ -550,9 +550,9 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
         {/* Head Circumference Chart */}
-        <div className="fade-in fade-in-10">
+        {isFeatureEnabled("headcirc") && <div className="fade-in fade-in-10">
           <SectionCard
             title={t("growth.headCircTrend")}
             icon={<Icons.Baby />}
@@ -595,10 +595,10 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
 
         {/* BMI Chart */}
-        <div className="fade-in fade-in-11">
+        {isFeatureEnabled("bmi") && <div className="fade-in fade-in-11">
           <SectionCard
             title={t("growth.bmiTrend")}
             icon={<Icons.TrendUp />}
@@ -633,7 +633,7 @@ export default function GrowthTab({ weights, heights, headCircumferences = [], b
               </div>
             )}
           </SectionCard>
-        </div>
+        </div>}
       </div>
 
       {dayModal && (

--- a/frontend/src/tabs/GrowthTab.test.jsx
+++ b/frontend/src/tabs/GrowthTab.test.jsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import GrowthTab from "./GrowthTab";
+import { I18nProvider } from "../utils/i18n";
+import { PreferencesProvider } from "../utils/preferences";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+function renderGrowthTab({ features } = {}) {
+  if (features) {
+    localStorage.setItem("babytracker_preferences", JSON.stringify({ features }));
+  }
+  render(
+    <I18nProvider>
+      <PreferencesProvider>
+        <GrowthTab
+          weights={[]}
+          heights={[]}
+          headCircumferences={[]}
+          bmiEntries={[]}
+          monthlyFeedings={[]}
+          monthlySleep={[]}
+          child={null}
+        />
+      </PreferencesProvider>
+    </I18nProvider>,
+  );
+}
+
+// Matches both feeding chart titles ("Daily Feeding - Amount (30d)" and
+// "Daily Feedings - Count (30d)") without pinning the exact wording.
+const FEEDING_TITLE = /^Daily Feeding/;
+
+describe("GrowthTab feature toggles", () => {
+  it("shows all charts by default", () => {
+    renderGrowthTab();
+    expect(screen.getAllByText(FEEDING_TITLE).length).toBe(2);
+    expect(screen.getByText("Daily Sleep (30d)")).toBeTruthy();
+    expect(screen.getByText("Weight Trend")).toBeTruthy();
+    expect(screen.getByText("Height Trend")).toBeTruthy();
+    expect(screen.getByText("Head Circumference")).toBeTruthy();
+    expect(screen.getByText("BMI Trend")).toBeTruthy();
+  });
+
+  it("hides both feeding charts when the feeding feature is disabled", () => {
+    renderGrowthTab({ features: { feeding: false } });
+    expect(screen.queryAllByText(FEEDING_TITLE).length).toBe(0);
+    expect(screen.getByText("Daily Sleep (30d)")).toBeTruthy();
+  });
+
+  it("hides the sleep chart when the sleep feature is disabled", () => {
+    renderGrowthTab({ features: { sleep: false } });
+    expect(screen.queryByText("Daily Sleep (30d)")).toBeNull();
+    expect(screen.getAllByText(FEEDING_TITLE).length).toBe(2);
+  });
+
+  it("hides the BMI tile and chart when the bmi feature is disabled", () => {
+    renderGrowthTab({ features: { bmi: false } });
+    expect(screen.queryByText("BMI Trend")).toBeNull();
+    expect(screen.queryByText("BMI")).toBeNull();
+    expect(screen.getByText("Weight Trend")).toBeTruthy();
+  });
+
+  it("hides measurement tiles and trend charts for disabled growth features", () => {
+    renderGrowthTab({ features: { weight: false, height: false, headcirc: false } });
+    expect(screen.queryByText("Weight Trend")).toBeNull();
+    expect(screen.queryByText("Height Trend")).toBeNull();
+    expect(screen.queryByText("Head Circumference")).toBeNull();
+    expect(screen.getByText("BMI Trend")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
The settings feature toggles already hide sections on the Overview tab and filter the quick actions, but the Growth tab ignored them entirely — disabling e.g. Feeding still showed both feeding charts.

This gates every Growth card with `isFeatureEnabled`, following the existing OverviewTab pattern:

- Weight / Height / Head Circumference / BMI measurement tiles and trend charts → their respective toggles
- Daily Feeding Amount + Count charts → `feeding`
- Daily Sleep chart → `sleep`

Also adds component tests for the default and disabled states.

Replaces #6, rebuilt on main after #5 was merged.