### PR TITLE
Bump all GitHub Actions to Node 24 runtimes; drop the dead build cache

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -18,13 +18,13 @@ jobs:
     timeout-minutes: 20
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -54,7 +54,7 @@ jobs:
           cat babytracker-linux-${{ matrix.arch }}.sha256
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: babytracker-linux-${{ matrix.arch }}
           path: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             babytracker-linux-${{ matrix.arch }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/docker/Dockerfile
@@ -51,5 +51,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/build-pi-image.yml
+++ b/.github/workflows/build-pi-image.yml
@@ -22,13 +22,13 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.25'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -273,7 +273,7 @@ jobs:
           ls -lh "${IMG}.xz"
 
       - name: Upload entire output dir
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: babytracker-pi-image
           path: |
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             /tmp/rpi-image-gen/work/image-babytracker/*.img.xz

--- a/.github/workflows/build-proxmox-lxc.yml
+++ b/.github/workflows/build-proxmox-lxc.yml
@@ -15,13 +15,13 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.25'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
 
@@ -51,7 +51,7 @@ jobs:
                deploy/proxmox/lxc/build-lxc-template.sh
 
       - name: Upload LXC template
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: babytracker-lxc-template
           path: output/babytracker-lxc-*.tar.zst
@@ -59,6 +59,6 @@ jobs:
 
       - name: Upload to release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: output/babytracker-lxc-*.tar.zst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.26'
 
@@ -51,9 +51,9 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: npm


### PR DESCRIPTION
Follow-up to the v1.10.2 release, covering the two things flagged there.

## Action versions

Every action in every workflow was one to three majors behind, and all were emitting the Node 20 deprecation warning on each run. GitHub currently force-runs them on Node 24 anyway — this catches up before that stops being automatic.

| action | from | to |
| --- | --- | --- |
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/setup-go` | v5 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `softprops/action-gh-release` | v2 | v3 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

I read the release notes for each major being crossed rather than assuming they were safe. Almost all are pure Node 24 runtime bumps. The three with real behaviour changes don't apply here:

- **checkout v7** blocks fork checkouts for `pull_request_target` / `workflow_run` — neither trigger is used anywhere.
- **setup-node v5** auto-enables caching when `package.json` has a `packageManager` field — `frontend/package.json` doesn't have one.
- **upload-artifact v7** adds an `archive` input — opt-in, existing usage unaffected.

All jobs run on GitHub-hosted `ubuntu-24.04` / `ubuntu-24.04-arm`, well past the v2.327.1 minimum runner these versions require.

## Dead build cache

Removes `cache-from` / `cache-to: type=gha` from the Docker build. It never produced a hit: the workflow only runs on tags, Actions caches are ref-scoped, and nothing populates a cache on the default branch — so every release imported a manifest and then rebuilt from scratch anyway. The v1.10.1 run logged **zero** `CACHED` steps.

It was writing roughly a gigabyte of buildkit blobs nobody could read. Now that the build cross-compiles and finishes in ~3 minutes, the cache has nothing to buy back.

If you'd rather keep a cache, the option that would actually work across tags is registry-backed (`type=registry,ref=ghcr.io/mbentancour/babytracker:buildcache`), since it lives in GHCR rather than the ref-scoped Actions store. I left it out — it adds an image to the package listing to save maybe two minutes.

## Validation

- All five workflow files parse cleanly.
- `ci.yml` is the only workflow that runs on `pull_request`, so **this PR validates the checkout / setup-node / setup-go bumps only**. The four release workflows trigger on tags, so their bumps — including `action-gh-release` and the `docker/*` chain — get their first real exercise at the next release. Worth watching that one.